### PR TITLE
Revert to classic JSX runtime

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -24,7 +24,7 @@ module.exports = {
         },
       },
     ],
-    ['@babel/preset-react', {runtime: 'automatic'}],
+    ['@babel/preset-react', {runtime: 'classic'}],
     '@babel/preset-flow',
   ],
 };

--- a/packages/lexical-react/src/LexicalContentEditable.tsx
+++ b/packages/lexical-react/src/LexicalContentEditable.tsx
@@ -10,6 +10,7 @@ import type {Props as ElementProps} from './shared/LexicalContentEditableElement
 import type {LexicalEditor} from 'lexical';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import * as React from 'react';
 import {forwardRef, Ref, useLayoutEffect, useState} from 'react';
 
 import {ContentEditableElement} from './shared/LexicalContentEditableElement';

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -72,8 +72,6 @@ const wwwMappings = {
   'prismjs/components/prism-swift': 'prism-swift',
   'prismjs/components/prism-typescript': 'prism-typescript',
   'react-dom': 'ReactDOM',
-  // The react entrypoint in fb includes the jsx runtime
-  'react/jsx-runtime': 'react',
 };
 
 /**
@@ -203,7 +201,7 @@ async function build(
               tsconfig: path.resolve('./tsconfig.build.json'),
             },
           ],
-          ['@babel/preset-react', {runtime: 'automatic'}],
+          ['@babel/preset-react', {runtime: 'classic'}],
         ],
       }),
       {


### PR DESCRIPTION
<!-- 
Title format should be:
[Affected Packages] PR Type: title

Example:
[lexical-playground][lexical-link] Feature: Add more emojis 

Choose from the following PR Types:
Breaking change / Refactor / Feature / Bug Fix / Documentation Update / Chore
-->

This PR reverts the JSX transformer to use the `classic` option from `@babel/preset-react`.
The automatic JSX runtime doesn't support React < 18.0 which we are currently using.

https://babeljs.io/blog/2020/03/16/7.9.0#a-new-jsx-transform-11154

## Description
<!-- 
- What is the current behavior that you are modifying? 
- What are the behavior or changes that are being added by this PR?
-->
*Describe the changes in this pull request*

Closes #<!-- issue number -->

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*